### PR TITLE
Add `--query` for `fzf_history` and properly escape the command

### DIFF
--- a/fzf.lua
+++ b/fzf.lua
@@ -131,7 +131,7 @@ local function till_cursor(line_state, start)
 end
 
 local function quote_arg(arg)
-    return '"'..arg:gsub('"', '\\"')..'"'
+    return '"'..arg:gsub('(\\+)"', '%1%1"'):gsub('"', '\\"')..'"'
 end
 
 local function escape_cmd(cmd)


### PR DESCRIPTION
While `--query` is used for other commands, it is currently disabled for `fzf_history` with this comment in the code

```
    -- This intentionally does not use '--query' because that isn't safe:
    -- Depending on what the user has typed so far, passing it as an argument
    -- may cause the command to interpreted differently than expected.
    -- E.g. suppose the user typed:     "pgm.exe & rd /s
    -- Then fzf would be invoked as:    fzf.exe --query""pgm.exe & rd /s"
    -- And since the & is not inside quotes, the 'rd /s' command gets actually
    -- run by mistake!
```

This is my attempt at properly quoting the command so that such issues do not happen. Quoting the argument for a command is easy. We just need to quote it and escape all literal quotes. The tricky part is that `io.popen` seems to internally call a `cmd /c`. So the command needs to be quoted again for cmd's parsing.

The way `cmd.exe` parses its command line is weird. But from some research, the easiest way to quote it appears to be to wrap the entire thing in quotes and then escape all special characters with `^`. `|&<>%^!` is all the special chars that I know of. I also found some sources that claim `()@` may need to be escaped under certain conditions. So I've added them to the list as well (Escaping characters that don't need it appears to be harmless)